### PR TITLE
Remplacer ollama par groq en local

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,17 @@
+# Configuration pour l'API Groq
+# Copiez ce fichier en .env et ajoutez votre clé API
+
+# Clé API Groq (obligatoire)
+# Obtenez votre clé gratuite sur: https://console.groq.com/keys
+GROQ_API_KEY=your_groq_api_key_here
+
+# Configuration optionnelle
+# Modèle par défaut (optionnel)
+# Options: mixtral-8x7b-32768, llama3-8b-8192, llama3-70b-8192, llama2-70b-4096, gemma-7b-it, gemma2-9b-it
+DEFAULT_MODEL=mixtral-8x7b-32768
+
+# Température par défaut (optionnel, entre 0 et 2)
+DEFAULT_TEMPERATURE=0.7
+
+# Nombre maximum de tokens par défaut (optionnel)
+DEFAULT_MAX_TOKENS=1024

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,62 @@
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# Virtual Environment
+venv/
+ENV/
+env/
+.venv
+
+# Environment variables
+.env
+.env.local
+.env.*.local
+
+# IDE
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+.DS_Store
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# Testing
+.pytest_cache/
+.coverage
+htmlcov/
+
+# Logs
+*.log
+
+# Database
+*.db
+*.sqlite3
+
+# Secrets
+*.pem
+*.key
+secrets/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,200 @@
-# MerciLev
+# Migration d'Ollama vers Groq API
+
+Ce projet fournit une interface simple pour utiliser l'API Groq en remplacement d'Ollama pour l'inférence de modèles de langage.
+
+## 🚀 Pourquoi Groq au lieu d'Ollama ?
+
+### Avantages de Groq :
+- **Performance ultra-rapide** : Groq utilise des puces LPU (Language Processing Units) spécialisées offrant une vitesse d'inférence exceptionnelle
+- **Pas d'installation locale** : Contrairement à Ollama, pas besoin de télécharger des modèles de plusieurs GB
+- **API cloud** : Accessible depuis n'importe où, pas de ressources locales requises
+- **Modèles de pointe** : Accès à Mixtral, Llama 3, Gemma et plus
+- **Tarification généreuse** : Tier gratuit très généreux pour commencer
+
+### Comparaison :
+| Caractéristique | Ollama | Groq |
+|----------------|---------|------|
+| Installation | Locale (GB de stockage) | API Cloud |
+| Vitesse | Dépend du hardware local | Ultra-rapide (LPU) |
+| Modèles | Téléchargement manuel | Accès immédiat |
+| GPU requis | Recommandé | Non |
+| Coût | Gratuit (ressources locales) | Tier gratuit généreux |
+
+## 📦 Installation
+
+1. Clonez ce repository
+2. Installez les dépendances :
+```bash
+pip install -r requirements.txt
+```
+
+3. Configurez votre clé API :
+```bash
+cp .env.example .env
+# Éditez .env et ajoutez votre clé API Groq
+```
+
+4. Obtenez votre clé API gratuite sur : https://console.groq.com/keys
+
+## 🔧 Utilisation
+
+### Client Groq de base
+
+```python
+from groq_client import GroqClient
+
+# Initialiser le client
+client = GroqClient()
+
+# Chat simple
+response = client.chat_completion(
+    messages=[
+        {"role": "user", "content": "Bonjour, comment vas-tu ?"}
+    ],
+    model="mixtral-8x7b-32768"
+)
+print(response)
+```
+
+### Migration depuis Ollama
+
+**Code Ollama original :**
+```python
+import ollama
+
+response = ollama.chat(model='llama2', messages=[
+    {'role': 'user', 'content': 'Explique la récursion'},
+])
+print(response['message']['content'])
+```
+
+**Code Groq équivalent :**
+```python
+from groq_client import GroqClient
+
+client = GroqClient()
+response = client.chat_completion(
+    messages=[
+        {'role': 'user', 'content': 'Explique la récursion'},
+    ],
+    model='llama2-70b-4096'
+)
+print(response)
+```
+
+### Streaming de réponses
+
+```python
+# Streaming avec Groq
+for chunk in client.stream_chat_completion(messages):
+    print(chunk, end="", flush=True)
+```
+
+## 🤖 Modèles disponibles
+
+| Modèle | Context Window | Description |
+|--------|----------------|-------------|
+| mixtral-8x7b-32768 | 32,768 tokens | Mixture of Experts, excellent pour les tâches complexes |
+| llama3-70b-8192 | 8,192 tokens | Llama 3 70B, très performant |
+| llama3-8b-8192 | 8,192 tokens | Llama 3 8B, rapide et efficace |
+| llama2-70b-4096 | 4,096 tokens | Llama 2 70B, modèle stable |
+| gemma-7b-it | 8,192 tokens | Gemma de Google, optimisé pour les instructions |
+| gemma2-9b-it | 8,192 tokens | Gemma 2 amélioré |
+
+## 📝 Exemples
+
+Exécutez les exemples fournis :
+```bash
+python example_usage.py
+```
+
+Les exemples incluent :
+- Chat basique
+- Streaming de réponses
+- Conversations multi-tours
+- Utilisation de différents modèles
+- Guide de migration depuis Ollama
+
+## 🔄 Guide de migration complet
+
+### 1. Initialisation
+```python
+# Ollama
+import ollama
+# Pas de configuration nécessaire
+
+# Groq
+from groq_client import GroqClient
+client = GroqClient()  # Utilise GROQ_API_KEY de l'environnement
+```
+
+### 2. Chat simple
+```python
+# Ollama
+response = ollama.chat(model='llama2', messages=messages)
+content = response['message']['content']
+
+# Groq
+response = client.chat_completion(messages=messages, model='llama2-70b-4096')
+content = response  # Retourne directement le contenu
+```
+
+### 3. Streaming
+```python
+# Ollama
+stream = ollama.chat(model='llama2', messages=messages, stream=True)
+for chunk in stream:
+    print(chunk['message']['content'], end='')
+
+# Groq
+for chunk in client.stream_chat_completion(messages=messages):
+    print(chunk, end='')
+```
+
+### 4. Paramètres
+```python
+# Ollama
+response = ollama.chat(
+    model='llama2',
+    messages=messages,
+    options={
+        'temperature': 0.7,
+        'top_p': 0.9,
+    }
+)
+
+# Groq
+response = client.chat_completion(
+    messages=messages,
+    model='llama2-70b-4096',
+    temperature=0.7,
+    top_p=0.9,
+    max_tokens=1024
+)
+```
+
+## 💡 Conseils
+
+1. **Performance** : Groq est optimisé pour la vitesse. Profitez-en pour des applications temps réel.
+2. **Limites** : Respectez les limites de rate du tier gratuit (consultez la documentation Groq).
+3. **Modèles** : Mixtral-8x7b offre le meilleur rapport qualité/performance pour la plupart des cas.
+4. **Contexte** : Utilisez des modèles avec grandes fenêtres de contexte pour les conversations longues.
+
+## 🔒 Sécurité
+
+- Ne commitez jamais votre clé API
+- Utilisez des variables d'environnement
+- Ajoutez `.env` à votre `.gitignore`
+
+## 📚 Ressources
+
+- [Documentation Groq](https://console.groq.com/docs)
+- [Console Groq](https://console.groq.com)
+- [Playground Groq](https://console.groq.com/playground)
+
+## 🤝 Support
+
+Pour des questions ou problèmes :
+1. Consultez les exemples dans `example_usage.py`
+2. Vérifiez la [documentation officielle Groq](https://console.groq.com/docs)
+3. Assurez-vous que votre clé API est valide et active

--- a/example_usage.py
+++ b/example_usage.py
@@ -1,0 +1,185 @@
+"""
+Exemple d'utilisation de l'API Groq en remplacement d'Ollama
+"""
+import asyncio
+from groq_client import GroqClient
+
+def example_basic_chat():
+    """Exemple de chat basique avec Groq"""
+    print("=== Exemple de Chat Basique ===\n")
+    
+    # Initialiser le client Groq
+    client = GroqClient()
+    
+    # Préparer les messages
+    messages = [
+        {"role": "system", "content": "Tu es un assistant utile et concis."},
+        {"role": "user", "content": "Explique-moi la différence entre Groq et Ollama en quelques points."}
+    ]
+    
+    # Envoyer la requête
+    response = client.chat_completion(
+        messages=messages,
+        model="mixtral-8x7b-32768",
+        temperature=0.7,
+        max_tokens=500
+    )
+    
+    print(f"Réponse: {response}\n")
+
+def example_streaming():
+    """Exemple de streaming de réponse"""
+    print("=== Exemple de Streaming ===\n")
+    
+    client = GroqClient()
+    
+    messages = [
+        {"role": "user", "content": "Écris une histoire courte sur un robot qui apprend à cuisiner."}
+    ]
+    
+    print("Réponse en streaming: ", end="", flush=True)
+    for chunk in client.stream_chat_completion(messages, max_tokens=200):
+        print(chunk, end="", flush=True)
+    print("\n")
+
+def example_conversation():
+    """Exemple de conversation multi-tours"""
+    print("=== Exemple de Conversation ===\n")
+    
+    client = GroqClient()
+    
+    # Historique de conversation
+    conversation = [
+        {"role": "system", "content": "Tu es un expert en programmation Python."}
+    ]
+    
+    # Premier tour
+    conversation.append({"role": "user", "content": "Comment créer une classe en Python?"})
+    response1 = client.chat_completion(conversation, temperature=0.5)
+    print(f"User: Comment créer une classe en Python?")
+    print(f"Assistant: {response1}\n")
+    
+    # Ajouter la réponse à l'historique
+    conversation.append({"role": "assistant", "content": response1})
+    
+    # Deuxième tour
+    conversation.append({"role": "user", "content": "Peux-tu me donner un exemple avec héritage?"})
+    response2 = client.chat_completion(conversation, temperature=0.5)
+    print(f"User: Peux-tu me donner un exemple avec héritage?")
+    print(f"Assistant: {response2}\n")
+
+def example_different_models():
+    """Exemple d'utilisation de différents modèles"""
+    print("=== Exemple avec Différents Modèles ===\n")
+    
+    client = GroqClient()
+    
+    # Lister les modèles disponibles
+    models = client.list_models()
+    print(f"Modèles disponibles: {models}\n")
+    
+    # Tester avec différents modèles
+    test_models = ["mixtral-8x7b-32768", "llama3-8b-8192", "gemma-7b-it"]
+    question = "Qu'est-ce que Python en une phrase?"
+    
+    for model in test_models:
+        try:
+            print(f"Modèle: {model}")
+            info = client.get_model_info(model)
+            print(f"Info: {info['name']} - Context: {info['context_window']} tokens")
+            
+            response = client.chat_completion(
+                [{"role": "user", "content": question}],
+                model=model,
+                temperature=0.3,
+                max_tokens=100
+            )
+            print(f"Réponse: {response}\n")
+        except Exception as e:
+            print(f"Erreur avec {model}: {e}\n")
+
+def example_migration_from_ollama():
+    """
+    Exemple montrant comment migrer du code Ollama vers Groq
+    """
+    print("=== Migration Ollama -> Groq ===\n")
+    
+    print("Code Ollama original:")
+    print("""
+    # Avec Ollama
+    import ollama
+    
+    response = ollama.chat(model='llama2', messages=[
+        {
+            'role': 'user',
+            'content': 'Pourquoi le ciel est-il bleu?',
+        },
+    ])
+    print(response['message']['content'])
+    """)
+    
+    print("\nCode Groq équivalent:")
+    print("""
+    # Avec Groq
+    from groq_client import GroqClient
+    
+    client = GroqClient()
+    response = client.chat_completion(
+        messages=[
+            {
+                'role': 'user',
+                'content': 'Pourquoi le ciel est-il bleu?',
+            },
+        ],
+        model='llama2-70b-4096'  # ou un autre modèle disponible
+    )
+    print(response)
+    """)
+    
+    # Exécution réelle
+    print("\nExécution avec Groq:")
+    client = GroqClient()
+    response = client.chat_completion(
+        messages=[
+            {
+                'role': 'user',
+                'content': 'Pourquoi le ciel est-il bleu?',
+            },
+        ],
+        model='llama3-8b-8192',
+        temperature=0.5,
+        max_tokens=200
+    )
+    print(f"Réponse: {response}")
+
+if __name__ == "__main__":
+    print("Exemples d'utilisation de Groq API\n")
+    print("=" * 50)
+    
+    # Vérifier que la clé API est configurée
+    import os
+    if not os.getenv("GROQ_API_KEY"):
+        print("⚠️  ATTENTION: La variable d'environnement GROQ_API_KEY n'est pas définie!")
+        print("Veuillez configurer votre clé API Groq dans le fichier .env")
+        print("Vous pouvez obtenir une clé API gratuite sur: https://console.groq.com/keys")
+        exit(1)
+    
+    try:
+        # Exécuter les exemples
+        example_basic_chat()
+        print("\n" + "=" * 50 + "\n")
+        
+        example_streaming()
+        print("\n" + "=" * 50 + "\n")
+        
+        example_conversation()
+        print("\n" + "=" * 50 + "\n")
+        
+        example_different_models()
+        print("\n" + "=" * 50 + "\n")
+        
+        example_migration_from_ollama()
+        
+    except Exception as e:
+        print(f"\n❌ Erreur: {e}")
+        print("Assurez-vous que votre clé API Groq est valide et que vous avez une connexion internet.")

--- a/groq_client.py
+++ b/groq_client.py
@@ -1,0 +1,163 @@
+"""
+Client pour l'API Groq - Remplace Ollama pour l'inférence LLM
+"""
+import os
+from typing import List, Dict, Optional, Union
+from groq import Groq
+from dotenv import load_dotenv
+
+# Charger les variables d'environnement
+load_dotenv()
+
+class GroqClient:
+    """Client pour interagir avec l'API Groq"""
+    
+    def __init__(self, api_key: Optional[str] = None):
+        """
+        Initialise le client Groq
+        
+        Args:
+            api_key: Clé API Groq (optionnel, peut être définie via GROQ_API_KEY)
+        """
+        self.api_key = api_key or os.getenv("GROQ_API_KEY")
+        if not self.api_key:
+            raise ValueError("Clé API Groq non fournie. Définissez GROQ_API_KEY dans votre environnement.")
+        
+        self.client = Groq(api_key=self.api_key)
+        
+    def chat_completion(
+        self,
+        messages: List[Dict[str, str]],
+        model: str = "mixtral-8x7b-32768",
+        temperature: float = 0.7,
+        max_tokens: int = 1024,
+        stream: bool = False,
+        **kwargs
+    ) -> Union[str, Dict]:
+        """
+        Envoie une requête de chat completion à l'API Groq
+        
+        Args:
+            messages: Liste des messages de la conversation
+            model: Modèle à utiliser (par défaut: mixtral-8x7b-32768)
+            temperature: Température pour la génération (0-2)
+            max_tokens: Nombre maximum de tokens à générer
+            stream: Si True, retourne un générateur pour le streaming
+            **kwargs: Autres paramètres supportés par l'API Groq
+            
+        Returns:
+            Réponse du modèle sous forme de string ou dictionnaire complet
+        """
+        try:
+            chat_completion = self.client.chat.completions.create(
+                messages=messages,
+                model=model,
+                temperature=temperature,
+                max_tokens=max_tokens,
+                stream=stream,
+                **kwargs
+            )
+            
+            if stream:
+                return chat_completion
+            
+            return chat_completion.choices[0].message.content
+            
+        except Exception as e:
+            raise Exception(f"Erreur lors de l'appel à l'API Groq: {str(e)}")
+    
+    def stream_chat_completion(
+        self,
+        messages: List[Dict[str, str]],
+        model: str = "mixtral-8x7b-32768",
+        temperature: float = 0.7,
+        max_tokens: int = 1024,
+        **kwargs
+    ):
+        """
+        Stream la réponse du modèle token par token
+        
+        Args:
+            messages: Liste des messages de la conversation
+            model: Modèle à utiliser
+            temperature: Température pour la génération
+            max_tokens: Nombre maximum de tokens à générer
+            **kwargs: Autres paramètres supportés par l'API Groq
+            
+        Yields:
+            Chunks de la réponse au fur et à mesure
+        """
+        stream = self.chat_completion(
+            messages=messages,
+            model=model,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            stream=True,
+            **kwargs
+        )
+        
+        for chunk in stream:
+            if chunk.choices[0].delta.content is not None:
+                yield chunk.choices[0].delta.content
+    
+    def list_models(self) -> List[str]:
+        """
+        Liste les modèles disponibles sur Groq
+        
+        Returns:
+            Liste des identifiants de modèles disponibles
+        """
+        available_models = [
+            "mixtral-8x7b-32768",
+            "llama3-8b-8192",
+            "llama3-70b-8192",
+            "llama2-70b-4096",
+            "gemma-7b-it",
+            "gemma2-9b-it"
+        ]
+        return available_models
+    
+    def get_model_info(self, model: str) -> Dict[str, Union[str, int]]:
+        """
+        Retourne les informations sur un modèle spécifique
+        
+        Args:
+            model: Identifiant du modèle
+            
+        Returns:
+            Dictionnaire avec les informations du modèle
+        """
+        model_info = {
+            "mixtral-8x7b-32768": {
+                "name": "Mixtral 8x7B",
+                "context_window": 32768,
+                "description": "Modèle Mixture of Experts performant avec une grande fenêtre de contexte"
+            },
+            "llama3-8b-8192": {
+                "name": "Llama 3 8B",
+                "context_window": 8192,
+                "description": "Version 8B de Llama 3, rapide et efficace"
+            },
+            "llama3-70b-8192": {
+                "name": "Llama 3 70B",
+                "context_window": 8192,
+                "description": "Version 70B de Llama 3, plus puissante"
+            },
+            "llama2-70b-4096": {
+                "name": "Llama 2 70B",
+                "context_window": 4096,
+                "description": "Llama 2 70B, modèle robuste et bien testé"
+            },
+            "gemma-7b-it": {
+                "name": "Gemma 7B",
+                "context_window": 8192,
+                "description": "Modèle Gemma de Google, optimisé pour les instructions"
+            },
+            "gemma2-9b-it": {
+                "name": "Gemma 2 9B",
+                "context_window": 8192,
+                "description": "Version améliorée de Gemma avec 9B paramètres"
+            }
+        }
+        
+        return model_info.get(model, {"error": "Modèle non trouvé"})

--- a/quick_test.py
+++ b/quick_test.py
@@ -1,0 +1,79 @@
+"""
+Script de test rapide pour vérifier l'installation et la configuration Groq
+"""
+import os
+import sys
+from groq_client import GroqClient
+
+def test_groq_setup():
+    """Test la configuration de Groq"""
+    print("🔍 Test de configuration Groq\n")
+    
+    # 1. Vérifier la clé API
+    print("1. Vérification de la clé API...")
+    api_key = os.getenv("GROQ_API_KEY")
+    if not api_key:
+        print("❌ GROQ_API_KEY non trouvée dans l'environnement")
+        print("   → Créez un fichier .env basé sur .env.example")
+        print("   → Ajoutez votre clé API depuis https://console.groq.com/keys")
+        return False
+    elif api_key == "your_groq_api_key_here":
+        print("❌ GROQ_API_KEY n'a pas été modifiée")
+        print("   → Remplacez 'your_groq_api_key_here' par votre vraie clé API")
+        return False
+    else:
+        print(f"✅ Clé API trouvée ({api_key[:8]}...)")
+    
+    # 2. Tester l'initialisation du client
+    print("\n2. Initialisation du client...")
+    try:
+        client = GroqClient()
+        print("✅ Client initialisé avec succès")
+    except Exception as e:
+        print(f"❌ Erreur lors de l'initialisation: {e}")
+        return False
+    
+    # 3. Tester un appel simple
+    print("\n3. Test d'appel API...")
+    try:
+        response = client.chat_completion(
+            messages=[{"role": "user", "content": "Réponds juste 'OK' si tu me reçois."}],
+            model="mixtral-8x7b-32768",
+            max_tokens=10,
+            temperature=0
+        )
+        print(f"✅ Réponse reçue: {response.strip()}")
+    except Exception as e:
+        print(f"❌ Erreur lors de l'appel API: {e}")
+        print("   → Vérifiez que votre clé API est valide")
+        print("   → Vérifiez votre connexion internet")
+        return False
+    
+    # 4. Lister les modèles
+    print("\n4. Modèles disponibles:")
+    models = client.list_models()
+    for model in models:
+        info = client.get_model_info(model)
+        print(f"   • {model}: {info.get('name', 'N/A')} ({info.get('context_window', 'N/A')} tokens)")
+    
+    print("\n✅ Tous les tests sont passés ! Groq est prêt à l'emploi.")
+    print("\n📖 Prochaines étapes:")
+    print("   1. Explorez les exemples: python example_usage.py")
+    print("   2. Consultez le README.md pour plus d'informations")
+    print("   3. Commencez à coder avec Groq !")
+    
+    return True
+
+if __name__ == "__main__":
+    print("=" * 50)
+    print("Test de Configuration Groq API")
+    print("=" * 50)
+    
+    success = test_groq_setup()
+    
+    if not success:
+        print("\n⚠️  Configuration incomplète. Suivez les instructions ci-dessus.")
+        sys.exit(1)
+    else:
+        print("\n🎉 Configuration réussie !")
+        sys.exit(0)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+# Dépendances pour utiliser Groq API en remplacement d'Ollama
+groq==0.4.2
+python-dotenv==1.0.0
+requests==2.31.0
+typing-extensions==4.9.0


### PR DESCRIPTION
Add Groq API integration to replace local Ollama.

This PR introduces a complete Groq API integration, including a client, examples, documentation, and a quick test script, to enable the use of Groq's fast, cloud-based LLM inference instead of a local Ollama setup.

---
<a href="https://cursor.com/background-agent?bcId=bc-eed013e7-c4c6-4c4f-ab89-697cbc2d52d0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-eed013e7-c4c6-4c4f-ab89-697cbc2d52d0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

